### PR TITLE
feat: stabilize registration/login with transactions, add concurrency…

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,4 +1,5 @@
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from passlib.hash import bcrypt
 from models import Account, TeamMember
 from schemas import AccountRegister, TeamMemberCreate
@@ -6,6 +7,9 @@ from schemas import AccountRegister, TeamMemberCreate
 # Account CRUD
 def get_account_by_knox_id(db: Session, knox_id: str):
     return db.query(Account).filter(Account.knox_id == knox_id).first()
+
+def get_account_by_id(db: Session, account_id: int):
+    return db.query(Account).filter(Account.id == account_id).first()
 
 def create_or_update_account(db: Session, knox_id: str, password: str):
     hashed = bcrypt.hash(password)
@@ -16,32 +20,87 @@ def create_or_update_account(db: Session, knox_id: str, password: str):
         db.commit()
         db.refresh(account)
         return account
-    account = Account(knox_id=knox_id, hashed_password=hashed)
-    db.add(account)
-    db.commit()
-    db.refresh(account)
-    return account
+    
+    try:
+        account = Account(knox_id=knox_id, hashed_password=hashed)
+        db.add(account)
+        db.commit()
+        db.refresh(account)
+        return account
+    except IntegrityError:
+        # 동시에 같은 knox_id로 계정이 생성된 경우
+        db.rollback()
+        account = get_account_by_knox_id(db, knox_id)
+        if account:
+            if account.verify_password(password):
+                return account
+            else:
+                raise ValueError("이미 존재하는 계정입니다. 비밀번호가 다릅니다.")
+        else:
+            raise Exception("계정 생성 중 예상치 못한 오류가 발생했습니다.")
 
-def update_account_registration(db: Session, knox_id: str, registration_data: AccountRegister):
-    account = get_account_by_knox_id(db, knox_id)
-    if not account:
-        raise ValueError("Account not found")
-    
-    account.name = registration_data.name
-    account.team_name = registration_data.team_name
-    account.aidea = registration_data.aidea
-    
-    # To-Do: 올바른 방식인지 고민 필요
-    # 기존 팀원 삭제 및 추가
-    db.query(TeamMember).filter(TeamMember.account_id == account.id).delete()
-    for member_data in registration_data.team_members:
-        team_member = TeamMember(
-            account_id=account.id,
-            name=member_data.name,
-            knox_id=member_data.knox_id
-        )
-        db.add(team_member)
-    
-    db.commit()
-    db.refresh(account)
-    return account
+def update_account_registration(db: Session, registration_data: AccountRegister):
+    """
+    계정 등록 정보를 업데이트합니다. 트랜잭션 안전성을 보장하기 위해
+    원자적 연산을 사용합니다. 중간에 오류가 발생하면 모든 변경사항이 롤백됩니다.
+    동일 계정으로 동시에 제출하는 경우 고려하지 않음. 
+    """
+    try:
+        account = get_account_by_id(db, registration_data.id)
+        if not account:
+            raise ValueError(f"Account not found for knox_id: {registration_data.knox_id}")
+
+        if getattr(registration_data, "knox_id", None) and account.knox_id != registration_data.knox_id:
+            raise ValueError("요청의 knox_id가 계정 정보와 일치하지 않습니다.")
+        
+        # 입력 데이터 검증
+        if not registration_data.name or not registration_data.name.strip():
+            raise ValueError("이름은 필수입니다.")
+        if not registration_data.team_name or not registration_data.team_name.strip():
+            raise ValueError("팀명은 필수입니다.")
+        if len(registration_data.team_members) >3:
+            raise ValueError("팀원은 본인 포함 최대 4명까지 가능합니다.")
+        knox_ids = [m.knox_id for m in registration_data.team_members]
+        if registration_data.knox_id in knox_ids:
+            raise ValueError("본인 Knox ID와 동일한 팀원을 추가할 수 없습니다.")
+        if len(set(knox_ids)) != len(knox_ids):
+            raise ValueError("동일한 Knox ID인 팀원이 2명이상 존재하여 중복됩니다.")
+        
+        # 계정 기본 정보 업데이트
+        account.name = registration_data.name.strip()
+        account.team_name = registration_data.team_name.strip()
+        account.aidea = registration_data.aidea
+        db.add(account)
+        
+        existing_members = db.query(TeamMember).filter(TeamMember.account_id == account.id).all()
+        for member in existing_members:
+            db.delete(member)
+
+        for i, member_data in enumerate(registration_data.team_members):
+            if not member_data.name or not member_data.name.strip():
+                raise ValueError(f"팀원 {i+1}의 이름은 필수입니다.")
+            if not member_data.knox_id or not member_data.knox_id.strip():
+                raise ValueError(f"팀원 {i+1}의 knox_id는 필수입니다.")
+            
+            team_member = TeamMember(
+                account_id=account.id,
+                name=member_data.name.strip(),
+                knox_id=member_data.knox_id.strip()
+            )
+            db.add(team_member)
+        
+        db.commit()
+        db.refresh(account)
+        return account
+        
+    except ValueError as ve:
+        db.rollback()
+        raise ve
+    except IntegrityError as ie:
+        # 데이터베이스 무결성 오류 - 롤백 후 재발생
+        db.rollback()
+        raise ValueError(f"데이터 무결성 오류가 발생했습니다: {str(ie)}")
+    except Exception as e:
+        # 기타 예상치 못한 오류 - 롤백 후 재발생
+        db.rollback()
+        raise Exception(f"팀원 정보 업데이트 중 오류가 발생했습니다: {str(e)}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,10 +3,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from typing import List, Optional
 from pathlib import Path
 import os
 import uvicorn
+import logging
 
 from database import get_db, engine
 from models import Base
@@ -16,6 +18,13 @@ from schemas import (
 from crud import (
     create_or_update_account, get_account_by_knox_id, update_account_registration
 )
+
+ENVIRONMENT = os.getenv("ENVIRONMENT", "development").lower()
+if ENVIRONMENT == "development":
+    logging.basicConfig(level=logging.INFO)
+else:
+    logging.basicConfig(level=logging.CRITICAL + 1)
+logger = logging.getLogger(__name__)
 
 # 데이터베이스 테이블 생성
 Base.metadata.create_all(bind=engine)
@@ -36,36 +45,88 @@ async def health_check():
 
 @app.post("/api/login", response_model=AccountResponse)
 async def login_or_register_account(payload: AccountLogin, db: Session = Depends(get_db)):
-    if not payload.password or payload.password.strip() == "":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="패스워드는 필수입니다."
-        )
-    
-    account = get_account_by_knox_id(db, payload.knox_id)
+    """
+    로그인 또는 회원가입을 처리합니다.
+    동시성 문제를 방지하기 위해 안전한 트랜잭션 처리를 사용합니다.
+    """
+    try:
+        if not payload.password or payload.password.strip() == "":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="패스워드는 필수입니다."
+            )
+        
+        account = get_account_by_knox_id(db, payload.knox_id)
 
-    if account:
-        if account.verify_password(payload.password):
-            return account
+        if account:
+            if account.verify_password(payload.password):
+                logger.info(f"로그인 성공: {payload.knox_id}")
+                return account
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="패스워드가 다릅니다."
+            )
+            
+        account = create_or_update_account(db, knox_id=payload.knox_id, password=payload.password)
+        logger.info(f"새 계정 생성: {payload.knox_id}")
+        return account
+        
+    except ValueError as e:
+        logger.warning(f"계정 생성 시 비밀번호 불일치: {e}")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="패스워드가 다릅니다."
+            detail=str(e)
         )
-
-    account = create_or_update_account(db, knox_id=payload.knox_id, password=payload.password)
-    return account
+    except IntegrityError as e:
+        logger.error(f"데이터베이스 무결성 오류: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="이미 존재하는 계정입니다."
+        )
+    except SQLAlchemyError as e:
+        logger.error(f"데이터베이스 오류: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="서버 오류가 발생했습니다."
+        )
+    except Exception as e:
+        logger.error(f"예상치 못한 오류: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="서버 오류가 발생했습니다."
+        )
 
 @app.post("/api/register", response_model=AccountResponse)
 async def register_account(payload: AccountRegister, db: Session = Depends(get_db)):
+    """
+    계정 등록 정보를 업데이트합니다.
+    트랜잭션 안전성을 보장하고 동시성 문제를 방지합니다.
+    """
     try:
-        account = update_account_registration(db, payload.knox_id, payload)
+        account = update_account_registration(db, payload)
+        logger.info(f"계정 정보 등록 완료: knox_id={payload.knox_id}")
         return account
+        
     except ValueError as e:
+        logger.warning(f"ValueError: knox_id={payload.knox_id} - {e}")
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e)
         )
+    except IntegrityError as e:
+        logger.error(f"데이터베이스 무결성 오류: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="데이터 충돌이 발생했습니다. 다시 시도해주세요."
+        )
+    except SQLAlchemyError as e:
+        logger.error(f"데이터베이스 오류: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="서버 오류가 발생했습니다."
+        )
     except Exception as e:
+        logger.error(f"예상치 못한 오류: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="등록 중 오류가 발생했습니다."

--- a/backend/models.py
+++ b/backend/models.py
@@ -16,7 +16,6 @@ class Account(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
-    # 팀원과의 관계
     team_members = relationship("TeamMember", back_populates="account", cascade="all, delete-orphan")
 
     def verify_password(self, password: str) -> bool:
@@ -31,5 +30,4 @@ class TeamMember(Base):
     knox_id = Column(String, nullable=False)  # 팀원 Knox ID
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
-    # 계정과의 관계
     account = relationship("Account", back_populates="team_members")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -12,6 +12,7 @@ class TeamMemberCreate(BaseModel):
     knox_id: str
 
 class AccountRegister(BaseModel):
+    id: int
     knox_id: str
     name: str
     team_name: str

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -5,6 +5,7 @@ const Register = () => {
   const [currentStep, setCurrentStep] = useState('login'); // 'login' 또는 'register'
   const [loginData, setLoginData] = useState({
     id: '',
+    knoxId: '',
     password: ''
   });
   const [formData, setFormData] = useState({
@@ -59,6 +60,16 @@ const Register = () => {
     }
     
     if (newMember.name && newMember.knoxId) {
+      if (newMember.knoxId === loginData.knoxId) {
+        setTeamMemberLimitError('본인 Knox ID와 동일한 팀원을 추가할 수 없습니다.');
+        return;
+      }
+
+      if (teamMembers.some(member => member.knoxId === newMember.knoxId)) {
+        setTeamMemberLimitError('동일한 Knox ID인 팀원이 존재합니다.');
+        return;
+      }
+
       const member = {
         id: Date.now(),
         name: newMember.name,
@@ -108,7 +119,7 @@ const Register = () => {
       const res = await fetch('/api/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ knox_id: loginData.id, password: loginData.password })
+        body: JSON.stringify({ knox_id: loginData.knoxId, password: loginData.password })
       });
       
       if (!res.ok) {
@@ -126,7 +137,8 @@ const Register = () => {
       
       const accountData = await res.json();
       loadExistingData(accountData);
-      
+      setLoginData(prev => ({ ...prev, id: accountData.id }));
+
       setCurrentStep('register');
     } catch (err) {
       console.error(err);
@@ -142,7 +154,8 @@ const Register = () => {
     
     try {
       const registrationData = {
-        knox_id: loginData.id,
+        id: loginData.id,
+        knox_id: loginData.knoxId,
         name: formData.name,
         team_name: formData.team,
         aidea: formData.aidea,
@@ -196,13 +209,13 @@ const Register = () => {
                     <div className="form-section">
                       <h3>로그인 정보</h3>
                       <div className="mb-3">
-                        <label htmlFor="id" className="form-label">knox id *</label>
+                        <label htmlFor="knoxId" className="form-label">knox id *</label>
                         <input
                           type="text"
                           className="form-control"
-                          id="id"
-                          name="id"
-                          value={loginData.id}
+                          id="knoxId"
+                          name="knoxId"
+                          value={loginData.knoxId}
                           onChange={handleLoginInputChange}
                           required
                           placeholder="아이디를 입력하세요"
@@ -238,7 +251,7 @@ const Register = () => {
                       <button
                         type="submit"
                         className="btn btn-primary btn-lg w-100"
-                        disabled={!loginData.id || !loginData.password || isSubmitting}
+                        disabled={!loginData.knoxId || !loginData.password || isSubmitting}
                       >
                         {isSubmitting ? '로그인 중...' : '다음 단계로'}
                       </button>
@@ -332,7 +345,7 @@ const Register = () => {
                           className="form-control"
                         id="knoxId"
                         name="knoxId"
-                        value={loginData.id}
+                        value={loginData.knoxId}
                         readOnly
                         style={{ backgroundColor: '#f8f9fa', cursor: 'not-allowed' }}
                       />


### PR DESCRIPTION
트랜잭션/원자성 보장(예외 시 전부 롤백).
예외 매핑 강화

로그인 상태 분리: loginData.knoxId와 loginData.id(서버 반환 계정 id) 별도 관리.

로그인 성공 시 응답의 account.id 저장 후, 제안서 등록 요청 시 id로 판별